### PR TITLE
Enhance poetry related logging and add new flag

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -48,7 +48,7 @@ jobs:
         run: python -m pip install --force setuptools wheel
 
       - name: Install pipenv / poetry
-        run: python -m pip install pipenv poetry
+        run: python -m pip install pipenv==2021.11.5 poetry
 
       - name: Install serverless
         run: npm install -g serverless@2
@@ -99,7 +99,7 @@ jobs:
         run: python -m pip install --force setuptools wheel
 
       - name: Install pipenv / poetry
-        run: python -m pip install pipenv poetry
+        run: python -m pip install pipenv==2021.11.5 poetry
 
       - name: Install serverless
         run: npm install -g serverless@2
@@ -150,7 +150,7 @@ jobs:
         run: python -m pip install --force setuptools wheel
 
       - name: Install pipenv / poetry
-        run: python -m pip install pipenv poetry
+        run: python -m pip install pipenv==2021.11.5 poetry
 
       - name: Install serverless
         run: npm install -g serverless@2

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -13,9 +13,6 @@ jobs:
   windowsNode14:
     name: '[Windows] Node.js v14: Unit tests'
     runs-on: windows-latest
-    strategy:
-      matrix:
-        python-version: [2.7, 3.7]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -30,10 +27,10 @@ jobs:
           key: npm-v14-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
           restore-keys: npm-v14-${{ runner.os }}-${{ github.ref }}-
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.7
 
       - name: Install Node.js and npm
         uses: actions/setup-node@v1
@@ -64,9 +61,6 @@ jobs:
   linuxNode14:
     name: '[Linux] Node.js 14: Unit tests'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [2.7, 3.7]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -81,10 +75,10 @@ jobs:
           key: npm-v14-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
           restore-keys: npm-v14-${{ runner.os }}-${{ github.ref }}-
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.7
 
       - name: Install Node.js and npm
         uses: actions/setup-node@v1
@@ -115,9 +109,6 @@ jobs:
   linuxNode12:
     name: '[Linux] Node.js v12: Unit tests'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [2.7, 3.7]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -132,10 +123,10 @@ jobs:
           key: npm-v12-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
           restore-keys: npm-v12-${{ runner.os }}-${{ github.ref }}-
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.7
 
       - name: Install Node.js and npm
         uses: actions/setup-node@v1

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.6]
+        python-version: [2.7, 3.7]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.6]
+        python-version: [2.7, 3.7]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.6]
+        python-version: [2.7, 3.7]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -13,6 +13,9 @@ jobs:
   windowsNode14:
     name: '[Windows] Node.js v14: Unit tests'
     runs-on: windows-latest
+    strategy:
+      matrix:
+        sls-version: [2, 3]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -48,7 +51,7 @@ jobs:
         run: python -m pip install pipenv==2021.11.5 poetry
 
       - name: Install serverless
-        run: npm install -g serverless@2
+        run: npm install -g serverless@${{ matrix.sls-version }}
 
       - name: Install dependencies
         if: steps.cacheNpm.outputs.cache-hit != 'true'
@@ -61,6 +64,9 @@ jobs:
   linuxNode14:
     name: '[Linux] Node.js 14: Unit tests'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        sls-version: [2, 3]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -96,7 +102,7 @@ jobs:
         run: python -m pip install pipenv==2021.11.5 poetry
 
       - name: Install serverless
-        run: npm install -g serverless@2
+        run: npm install -g serverless@${{ matrix.sls-version }}
 
       - name: Install dependencies
         if: steps.cacheNpm.outputs.cache-hit != 'true'
@@ -144,7 +150,7 @@ jobs:
         run: python -m pip install pipenv==2021.11.5 poetry
 
       - name: Install serverless
-        run: npm install -g serverless@2
+        run: npm install -g serverless@${{ matrix.sls-version }}
 
       - name: Install dependencies
         if: steps.cacheNpm.outputs.cache-hit != 'true'
@@ -157,6 +163,9 @@ jobs:
   tagIfNewVersion:
     name: Tag if new version
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        sls-version: [2, 3]
     needs: [windowsNode14, linuxNode14, linuxNode12]
     steps:
       - name: Checkout repository

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.6]
+        python-version: [2.7, 3.7]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -93,7 +93,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.6]
+        python-version: [2.7, 3.7]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -146,7 +146,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.6]
+        python-version: [2.7, 3.7]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,6 +13,9 @@ jobs:
   linuxNode14:
     name: '[Linux] Node.js v14: Lint, Eventual Commitlint, Eventual Changelog, Formatting & Unit tests'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        sls-version: [2, 3]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -61,7 +64,7 @@ jobs:
         run: python -m pip install pipenv==2021.11.5 poetry
 
       - name: Install serverless
-        run: npm install -g serverless@2
+        run: npm install -g serverless@${{ matrix.sls-version }}
 
       - name: Install dependencies
         if: steps.cacheNpm.outputs.cache-hit != 'true'
@@ -88,6 +91,9 @@ jobs:
   windowsNode14:
     name: '[Windows] Node.js v14: Unit tests'
     runs-on: windows-latest
+    strategy:
+      matrix:
+        sls-version: [2, 3]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -125,7 +131,7 @@ jobs:
         run: python -m pip install pipenv==2021.11.5 poetry
 
       - name: Install serverless
-        run: npm install -g serverless@2
+        run: npm install -g serverless@${{ matrix.sls-version }}
 
       - name: Install dependencies
         if: steps.cacheNpm.outputs.cache-hit != 'true'
@@ -138,6 +144,9 @@ jobs:
   linuxNode12:
     name: '[Linux] Node.js v12: Unit tests'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        sls-version: [2, 3]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -175,7 +184,7 @@ jobs:
         run: python -m pip install pipenv==2021.11.5 poetry
 
       - name: Install serverless
-        run: npm install -g serverless@2
+        run: npm install -g serverless@${{ matrix.sls-version }}
 
       - name: Install dependencies
         if: steps.cacheNpm.outputs.cache-hit != 'true'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -61,7 +61,7 @@ jobs:
         run: python -m pip install --force setuptools wheel
 
       - name: Install pipenv / poetry
-        run: python -m pip install pipenv poetry
+        run: python -m pip install pipenv==2021.11.5 poetry
 
       - name: Install serverless
         run: npm install -g serverless@2
@@ -128,7 +128,7 @@ jobs:
         run: python -m pip install --force setuptools wheel
 
       - name: Install pipenv / poetry
-        run: python -m pip install pipenv poetry
+        run: python -m pip install pipenv==2021.11.5 poetry
 
       - name: Install serverless
         run: npm install -g serverless@2
@@ -181,7 +181,7 @@ jobs:
         run: python -m pip install --force setuptools wheel
 
       - name: Install pipenv / poetry
-        run: python -m pip install pipenv poetry
+        run: python -m pip install pipenv==2021.11.5 poetry
 
       - name: Install serverless
         run: npm install -g serverless@2

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,9 +13,6 @@ jobs:
   linuxNode14:
     name: '[Linux] Node.js v14: Lint, Eventual Commitlint, Eventual Changelog, Formatting & Unit tests'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [2.7, 3.7]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -43,10 +40,10 @@ jobs:
             npm-v14-${{ runner.os }}-${{ github.ref }}-
             npm-v14-${{ runner.os }}-refs/heads/master-
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.7
 
       - name: Install Node.js and npm
         uses: actions/setup-node@v1
@@ -91,9 +88,6 @@ jobs:
   windowsNode14:
     name: '[Windows] Node.js v14: Unit tests'
     runs-on: windows-latest
-    strategy:
-      matrix:
-        python-version: [2.7, 3.7]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -110,10 +104,10 @@ jobs:
             npm-v14-${{ runner.os }}-${{ github.ref }}-
             npm-v14-${{ runner.os }}-refs/heads/master-
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.7
 
       - name: Install Node.js and npm
         uses: actions/setup-node@v1
@@ -144,9 +138,6 @@ jobs:
   linuxNode12:
     name: '[Linux] Node.js v12: Unit tests'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [2.7, 3.7]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -163,10 +154,10 @@ jobs:
             npm-v12-${{ runner.os }}-${{ github.ref }}-
             npm-v12-${{ runner.os }}-refs/heads/master-
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.7
 
       - name: Install Node.js and npm
         uses: actions/setup-node@v1

--- a/README.md
+++ b/README.md
@@ -360,6 +360,9 @@ custom:
 
 ### Per-function requirements
 
+**Note: this feature does not work with Pipenv/Poetry, it requires `requirements.txt`
+files for your Python modules.**
+
 If you have different python functions, with different sets of requirements, you can avoid
 including all the unecessary dependencies of your functions by using the following structure:
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,15 @@ custom:
     usePoetry: false
 ```
 
+Be aware that if no `poetry.lock` file is present, a new one will be generated on the fly. To help having predictable builds,
+you can set the `requirePoetryLockFile` flag to true to throw an error when `poetry.lock` is missing.
+
+```yaml
+custom:
+  pythonRequirements:
+    requirePoetryLockFile: false
+```
+
 ### Poetry with git dependencies
 
 Poetry by default generates the exported requirements.txt file with `-e` and that breaks pip with `-t` parameter

--- a/example/serverless.yml
+++ b/example/serverless.yml
@@ -2,7 +2,7 @@ service: sls-py-req-test
 
 provider:
   name: aws
-  runtime: python3.6
+  runtime: python3.7
 
 plugins:
   - serverless-python-requirements

--- a/example_native_deps/serverless.yml
+++ b/example_native_deps/serverless.yml
@@ -2,7 +2,7 @@ service: sls-py-req-test
 
 provider:
   name: aws
-  runtime: python3.6
+  runtime: python3.7
 
 plugins:
   - serverless-python-requirements

--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ class ServerlessPythonRequirements {
   get targetFuncs() {
     let inputOpt = this.serverless.processedInput.options;
     return inputOpt.function
-      ? [inputOpt.functionObj]
+      ? [this.serverless.service.functions[inputOpt.function]]
       : values(this.serverless.service.functions).filter((func) => !func.image);
   }
 

--- a/index.js
+++ b/index.js
@@ -57,6 +57,7 @@ class ServerlessPythonRequirements {
         pipCmdExtraArgs: [],
         noDeploy: [],
         vendor: '',
+        requirePoetryLockFile: false,
       },
       (this.serverless.service.custom &&
         this.serverless.service.custom.pythonRequirements) ||

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -415,7 +415,9 @@ async function installRequirements(targetFolder, pluginInstance) {
 
         if (cmd === 'docker' && e.stderrBuffer) {
           throw new pluginInstance.serverless.classes.Error(
-            `Running ${cmd} failed with: "${e.stderrBuffer.toString().trim()}"`,
+            `Running "${cmd} ${args.join(' ')}" failed with: "${e.stderrBuffer
+              .toString()
+              .trim()}"`,
             'PYTHON_REQUIREMENTS_DOCKER_COMMAND_FAILED'
           );
         }

--- a/lib/pip.js
+++ b/lib/pip.js
@@ -412,6 +412,14 @@ async function installRequirements(targetFolder, pluginInstance) {
             'PYTHON_REQUIREMENTS_COMMAND_NOT_FOUND'
           );
         }
+
+        if (cmd === 'docker' && e.stderrBuffer) {
+          throw new pluginInstance.serverless.classes.Error(
+            `Running ${cmd} failed with: "${e.stderrBuffer.toString().trim()}"`,
+            'PYTHON_REQUIREMENTS_DOCKER_COMMAND_FAILED'
+          );
+        }
+
         if (log) {
           log.info(`Stdout: ${e.stdoutBuffer}`);
           log.info(`Stderr: ${e.stderrBuffer}`);

--- a/lib/poetry.js
+++ b/lib/poetry.js
@@ -21,12 +21,28 @@ async function pyprojectTomlToRequirements(modulePath, pluginInstance) {
     generateRequirementsProgress = progress.get(
       'python-generate-requirements-toml'
     );
-    generateRequirementsProgress.update(
-      'Generating requirements.txt from "pyproject.toml"'
-    );
-    log.info('Generating requirements.txt from "pyproject.toml"');
+  }
+
+  const emitMsg = (msg) => {
+    if (generateRequirementsProgress) {
+      generateRequirementsProgress.update(msg);
+      log.info(msg);
+    } else {
+      serverless.cli.log(msg);
+    }
+  };
+
+  if (fs.existsSync('poetry.lock')) {
+    emitMsg('Generating requirements.txt from poetry.lock');
   } else {
-    serverless.cli.log('Generating requirements.txt from pyproject.toml...');
+    if (options.requirePoetryLockFile) {
+      throw new serverless.classes.Error(
+        'poetry.lock file not found - set requirePoetryLockFile to false to ' +
+          'disable this error',
+        'MISSING_REQUIRED_POETRY_LOCK'
+      );
+    }
+    emitMsg('Generating poetry.lock and requirements.txt from pyproject.toml');
   }
 
   try {

--- a/test.js
+++ b/test.js
@@ -212,7 +212,6 @@ test(
         dockerImage: 'break the build to log the command',
       },
     });
-    console.log('STDOUT', stdout);
     t.true(
       stdout.includes(
         `-v ${__dirname}${sep}tests${sep}base${sep}custom_ssh:/root/.ssh/custom_ssh:z`

--- a/test.js
+++ b/test.js
@@ -239,11 +239,11 @@ test(
     t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
-  'py3.6 packages have the same hash',
+  'py3.7 packages have the same hash',
   async (t) => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
@@ -258,11 +258,11 @@ test(
     );
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
-  'py3.6 can package flask with default options',
+  'py3.7 can package flask with default options',
   async (t) => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
@@ -277,7 +277,7 @@ test(
 );
 
 test(
-  'py3.6 can package flask with hashes',
+  'py3.7 can package flask with hashes',
   async (t) => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
@@ -296,7 +296,7 @@ test(
 );
 
 test(
-  'py3.6 can package flask with nested',
+  'py3.7 can package flask with nested',
   async (t) => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
@@ -316,7 +316,7 @@ test(
 );
 
 test(
-  'py3.6 can package flask with zip option',
+  'py3.7 can package flask with zip option',
   async (t) => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
@@ -341,7 +341,7 @@ test(
 );
 
 test(
-  'py3.6 can package flask with slim option',
+  'py3.7 can package flask with slim option',
   async (t) => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
@@ -365,7 +365,7 @@ test(
 );
 
 test(
-  'py3.6 can package flask with slim & slimPatterns options',
+  'py3.7 can package flask with slim & slimPatterns options',
   async (t) => {
     process.chdir('tests/base');
     copySync('_slimPatterns.yml', 'slimPatterns.yml');
@@ -386,11 +386,11 @@ test(
     );
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
-  "py3.6 doesn't package bottle with noDeploy option",
+  "py3.7 doesn't package bottle with noDeploy option",
   async (t) => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
@@ -412,7 +412,7 @@ test(
 );
 
 test(
-  'py3.6 can package boto3 with editable',
+  'py3.7 can package boto3 with editable',
   async (t) => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
@@ -435,7 +435,7 @@ test(
 );
 
 test(
-  'py3.6 can package flask with dockerizePip option',
+  'py3.7 can package flask with dockerizePip option',
   async (t) => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
@@ -446,11 +446,11 @@ test(
     t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.6) || brokenOn('win32') }
+  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
 );
 
 test(
-  'py3.6 can package flask with slim & dockerizePip option',
+  'py3.7 can package flask with slim & dockerizePip option',
   async (t) => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
@@ -470,11 +470,11 @@ test(
     );
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.6) || brokenOn('win32') }
+  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
 );
 
 test(
-  'py3.6 can package flask with slim & dockerizePip & slimPatterns options',
+  'py3.7 can package flask with slim & dockerizePip & slimPatterns options',
   async (t) => {
     process.chdir('tests/base');
     copySync('_slimPatterns.yml', 'slimPatterns.yml');
@@ -495,11 +495,11 @@ test(
     );
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.6) || brokenOn('win32') }
+  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
 );
 
 test(
-  'py3.6 can package flask with zip & dockerizePip option',
+  'py3.7 can package flask with zip & dockerizePip option',
   async (t) => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
@@ -527,11 +527,11 @@ test(
     );
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.6) || brokenOn('win32') }
+  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
 );
 
 test(
-  'py3.6 can package flask with zip & slim & dockerizePip option',
+  'py3.7 can package flask with zip & slim & dockerizePip option',
   async (t) => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
@@ -561,7 +561,7 @@ test(
     );
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.6) || brokenOn('win32') }
+  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
 );
 
 test(
@@ -856,7 +856,7 @@ test(
 );
 
 test(
-  'pipenv py3.6 can package flask with default options',
+  'pipenv py3.7 can package flask with default options',
   async (t) => {
     process.chdir('tests/pipenv');
     const path = npm(['pack', '../..']);
@@ -871,11 +871,11 @@ test(
     );
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
-  'pipenv py3.6 can package flask with slim option',
+  'pipenv py3.7 can package flask with slim option',
   async (t) => {
     process.chdir('tests/pipenv');
     const path = npm(['pack', '../..']);
@@ -895,11 +895,11 @@ test(
     );
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
-  'pipenv py3.6 can package flask with slim & slimPatterns options',
+  'pipenv py3.7 can package flask with slim & slimPatterns options',
   async (t) => {
     process.chdir('tests/pipenv');
 
@@ -921,11 +921,11 @@ test(
     );
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
-  'pipenv py3.6 can package flask with zip option',
+  'pipenv py3.7 can package flask with zip option',
   async (t) => {
     process.chdir('tests/pipenv');
     const path = npm(['pack', '../..']);
@@ -946,11 +946,11 @@ test(
     );
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
-  "pipenv py3.6 doesn't package bottle with noDeploy option",
+  "pipenv py3.7 doesn't package bottle with noDeploy option",
   async (t) => {
     process.chdir('tests/pipenv');
     const path = npm(['pack', '../..']);
@@ -968,7 +968,7 @@ test(
     t.false(zipfiles.includes(`bottle.py`), 'bottle is NOT packaged');
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
@@ -983,7 +983,7 @@ test(
     t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
@@ -997,11 +997,11 @@ test(
     t.true(zipfiles.includes(`handler.py`), 'handler is packaged');
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
-  'poetry py3.6 can package flask with default options',
+  'poetry py3.7 can package flask with default options',
   async (t) => {
     process.chdir('tests/poetry');
     const path = npm(['pack', '../..']);
@@ -1013,11 +1013,11 @@ test(
     t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
-  'poetry py3.6 can package flask with slim option',
+  'poetry py3.7 can package flask with slim option',
   async (t) => {
     process.chdir('tests/poetry');
     const path = npm(['pack', '../..']);
@@ -1037,11 +1037,11 @@ test(
     );
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
-  'poetry py3.6 can package flask with slim & slimPatterns options',
+  'poetry py3.7 can package flask with slim & slimPatterns options',
   async (t) => {
     process.chdir('tests/poetry');
 
@@ -1063,11 +1063,11 @@ test(
     );
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
-  'poetry py3.6 can package flask with zip option',
+  'poetry py3.7 can package flask with zip option',
   async (t) => {
     process.chdir('tests/poetry');
     const path = npm(['pack', '../..']);
@@ -1092,7 +1092,7 @@ test(
 );
 
 test(
-  "poetry py3.6 doesn't package bottle with noDeploy option",
+  "poetry py3.7 doesn't package bottle with noDeploy option",
   async (t) => {
     process.chdir('tests/poetry');
     const path = npm(['pack', '../..']);
@@ -1110,11 +1110,11 @@ test(
     t.false(zipfiles.includes(`bottle.py`), 'bottle is NOT packaged');
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
-  'py3.6 can package flask with zip option and no explicit include',
+  'py3.7 can package flask with zip option and no explicit include',
   async (t) => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
@@ -1137,11 +1137,11 @@ test(
     );
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
-  'py3.6 can package lambda-decorators using vendor option',
+  'py3.7 can package lambda-decorators using vendor option',
   async (t) => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
@@ -1156,7 +1156,7 @@ test(
     );
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
@@ -1204,11 +1204,11 @@ test(
 
     t.end();
   },
-  { skip: process.platform === 'win32' || !hasPython(3.6) }
+  { skip: process.platform === 'win32' || !hasPython(3.7) }
 );
 
 test(
-  'py3.6 can package flask in a project with a space in it',
+  'py3.7 can package flask in a project with a space in it',
   async (t) => {
     copySync('tests/base', 'tests/base with a space');
     process.chdir('tests/base with a space');
@@ -1220,11 +1220,11 @@ test(
     t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
-  'py3.6 can package flask in a project with a space in it with docker',
+  'py3.7 can package flask in a project with a space in it with docker',
   async (t) => {
     copySync('tests/base', 'tests/base with a space');
     process.chdir('tests/base with a space');
@@ -1236,11 +1236,11 @@ test(
     t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.6) || brokenOn('win32') }
+  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
 );
 
 test(
-  'py3.6 supports custom file name with fileName option',
+  'py3.7 supports custom file name with fileName option',
   async (t) => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
@@ -1262,11 +1262,11 @@ test(
     );
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
-  "py3.6 doesn't package bottle with zip option",
+  "py3.7 doesn't package bottle with zip option",
   async (t) => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
@@ -1309,7 +1309,7 @@ test(
 );
 
 test(
-  'py3.6 can package flask with slim, slimPatterns & slimPatternsAppendDefaults=false options',
+  'py3.7 can package flask with slim, slimPatterns & slimPatternsAppendDefaults=false options',
   async (t) => {
     process.chdir('tests/base');
     copySync('_slimPatterns.yml', 'slimPatterns.yml');
@@ -1331,11 +1331,11 @@ test(
     );
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
-  'py3.6 can package flask with slim & dockerizePip & slimPatterns & slimPatternsAppendDefaults=false options',
+  'py3.7 can package flask with slim & dockerizePip & slimPatterns & slimPatternsAppendDefaults=false options',
   async (t) => {
     process.chdir('tests/base');
     copySync('_slimPatterns.yml', 'slimPatterns.yml');
@@ -1361,7 +1361,7 @@ test(
     );
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.6) || brokenOn('win32') }
+  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
 );
 
 test(
@@ -1426,7 +1426,7 @@ test(
 );
 
 test(
-  'pipenv py3.6 can package flask with slim & slimPatterns & slimPatternsAppendDefaults=false  option',
+  'pipenv py3.7 can package flask with slim & slimPatterns & slimPatternsAppendDefaults=false  option',
   async (t) => {
     process.chdir('tests/pipenv');
     copySync('_slimPatterns.yml', 'slimPatterns.yml');
@@ -1449,11 +1449,11 @@ test(
     );
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
-  'poetry py3.6 can package flask with slim & slimPatterns & slimPatternsAppendDefaults=false  option',
+  'poetry py3.7 can package flask with slim & slimPatterns & slimPatternsAppendDefaults=false  option',
   async (t) => {
     process.chdir('tests/poetry');
     copySync('_slimPatterns.yml', 'slimPatterns.yml');
@@ -1476,11 +1476,11 @@ test(
     );
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
-  'poetry py3.6 can package flask with package individually option',
+  'poetry py3.7 can package flask with package individually option',
   async (t) => {
     process.chdir('tests/poetry_individually');
     const path = npm(['pack', '../..']);
@@ -1495,11 +1495,11 @@ test(
     t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
-  'py3.6 can package flask with package individually option',
+  'py3.7 can package flask with package individually option',
   async (t) => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
@@ -1581,11 +1581,11 @@ test(
 
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
-  'py3.6 can package flask with package individually & slim option',
+  'py3.7 can package flask with package individually & slim option',
   async (t) => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
@@ -1667,7 +1667,7 @@ test(
 
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
@@ -1861,7 +1861,7 @@ test(
 );
 
 test(
-  'py3.6 can package only requirements of module',
+  'py3.7 can package only requirements of module',
   async (t) => {
     process.chdir('tests/individually');
     const path = npm(['pack', '../..']);
@@ -1917,11 +1917,11 @@ test(
 
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
-  'py3.6 can package lambda-decorators using vendor and invidiually option',
+  'py3.7 can package lambda-decorators using vendor and invidiually option',
   async (t) => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
@@ -1998,7 +1998,7 @@ test(
     );
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
@@ -2037,7 +2037,7 @@ test(
 
     t.end();
   },
-  { skip: process.platform === 'win32' || !hasPython(3.6) }
+  { skip: process.platform === 'win32' || !hasPython(3.7) }
 );
 
 test(
@@ -2076,11 +2076,11 @@ test(
 
     t.end();
   },
-  { skip: !canUseDocker() || process.platform === 'win32' || !hasPython(3.6) }
+  { skip: !canUseDocker() || process.platform === 'win32' || !hasPython(3.7) }
 );
 
 test(
-  'py3.6 uses download cache by default option',
+  'py3.7 uses download cache by default option',
   async (t) => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
@@ -2093,11 +2093,11 @@ test(
     );
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
-  'py3.6 uses download cache by default',
+  'py3.7 uses download cache by default',
   async (t) => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
@@ -2109,11 +2109,11 @@ test(
     );
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
-  'py3.6 uses download cache with dockerizePip option',
+  'py3.7 uses download cache with dockerizePip option',
   async (t) => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
@@ -2126,11 +2126,11 @@ test(
     );
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.6) || brokenOn('win32') }
+  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
 );
 
 test(
-  'py3.6 uses download cache with dockerizePip by default option',
+  'py3.7 uses download cache with dockerizePip by default option',
   async (t) => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
@@ -2144,11 +2144,11 @@ test(
     );
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.6) || brokenOn('win32') }
+  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
 );
 
 test(
-  'py3.6 uses static and download cache',
+  'py3.7 uses static and download cache',
   async (t) => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
@@ -2169,11 +2169,11 @@ test(
     );
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
-  'py3.6 uses static and download cache with dockerizePip option',
+  'py3.7 uses static and download cache with dockerizePip option',
   async (t) => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
@@ -2194,11 +2194,11 @@ test(
     );
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.6) || brokenOn('win32') }
+  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
 );
 
 test(
-  'py3.6 uses static cache',
+  'py3.7 uses static cache',
   async (t) => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
@@ -2220,7 +2220,7 @@ test(
       '.completed_requirements exists in static-cache'
     );
 
-    // py3.6 checking that static cache actually pulls from cache (by poisoning it)
+    // py3.7 checking that static cache actually pulls from cache (by poisoning it)
     writeFileSync(
       `${cachepath}${sep}${cacheFolderHash}_${arch}_slspyc${sep}injected_file_is_bad_form`,
       'injected new file into static cache folder'
@@ -2234,11 +2234,11 @@ test(
 
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
-  'py3.6 uses static cache with cacheLocation option',
+  'py3.7 uses static cache with cacheLocation option',
   async (t) => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
@@ -2261,11 +2261,11 @@ test(
     );
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );
 
 test(
-  'py3.6 uses static cache with dockerizePip & slim option',
+  'py3.7 uses static cache with dockerizePip & slim option',
   async (t) => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
@@ -2287,7 +2287,7 @@ test(
       '.completed_requirements exists in static-cache'
     );
 
-    // py3.6 checking that static cache actually pulls from cache (by poisoning it)
+    // py3.7 checking that static cache actually pulls from cache (by poisoning it)
     writeFileSync(
       `${cachepath}${sep}${cacheFolderHash}_${arch}_slspyc${sep}injected_file_is_bad_form`,
       'injected new file into static cache folder'
@@ -2306,11 +2306,11 @@ test(
 
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.6) || brokenOn('win32') }
+  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
 );
 
 test(
-  'py3.6 uses download cache with dockerizePip & slim option',
+  'py3.7 uses download cache with dockerizePip & slim option',
   async (t) => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
@@ -2332,11 +2332,11 @@ test(
 
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.6) || brokenOn('win32') }
+  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
 );
 
 test(
-  'py3.6 can ignore functions defined with `image`',
+  'py3.7 can ignore functions defined with `image`',
   async (t) => {
     process.chdir('tests/base');
     const path = npm(['pack', '../..']);
@@ -2365,5 +2365,5 @@ test(
 
     t.end();
   },
-  { skip: !hasPython(3.6) }
+  { skip: !hasPython(3.7) }
 );

--- a/test.js
+++ b/test.js
@@ -164,10 +164,6 @@ const getPythonBin = (version) => {
   return bin;
 };
 
-const hasPython = (version) => {
-  return Boolean(availablePythons[String(version)]);
-};
-
 const listZipFiles = async function (filename) {
   const file = await readFile(filename);
   const zip = await new JSZip().loadAsync(file);
@@ -227,54 +223,42 @@ test(
   { skip: !canUseDocker() || brokenOn('win32') }
 );
 
-test(
-  'default pythonBin can package flask with default options',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: {} });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+test('default pythonBin can package flask with default options', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: {} });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
+  t.end();
+});
 
-test(
-  'py3.7 packages have the same hash',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: {} });
-    const fileHash = sha256File('.serverless/sls-py-req-test.zip');
-    sls(['package'], { env: {} });
-    t.equal(
-      sha256File('.serverless/sls-py-req-test.zip'),
-      fileHash,
-      'packages have the same hash'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+test('py3.7 packages have the same hash', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: {} });
+  const fileHash = sha256File('.serverless/sls-py-req-test.zip');
+  sls(['package'], { env: {} });
+  t.equal(
+    sha256File('.serverless/sls-py-req-test.zip'),
+    fileHash,
+    'packages have the same hash'
+  );
+  t.end();
+});
 
-test(
-  'py3.7 can package flask with default options',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { pythonBin: getPythonBin(3) } });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
-    t.end();
-  },
-  { skip: !hasPython(3) }
-);
+test('py3.7 can package flask with default options', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { pythonBin: getPythonBin(3) } });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
+  t.end();
+});
 
 test(
   'py3.7 can package flask with hashes',
@@ -292,147 +276,119 @@ test(
     t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
     t.end();
   },
-  { skip: !hasPython(3) || brokenOn('win32') }
+  { skip: brokenOn('win32') }
 );
 
-test(
-  'py3.7 can package flask with nested',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], {
-      env: {
-        fileName: 'requirements-w-nested.txt',
-        pythonBin: getPythonBin(3),
-      },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
-    t.end();
-  },
-  { skip: !hasPython(3) }
-);
+test('py3.7 can package flask with nested', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], {
+    env: {
+      fileName: 'requirements-w-nested.txt',
+      pythonBin: getPythonBin(3),
+    },
+  });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
+  t.end();
+});
 
-test(
-  'py3.7 can package flask with zip option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { zip: 'true', pythonBin: getPythonBin(3) } });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(
-      zipfiles.includes('.requirements.zip'),
-      'zipped requirements are packaged'
-    );
-    t.true(
-      zipfiles.includes(`unzip_requirements.py`),
-      'unzip util is packaged'
-    );
-    t.false(
-      zipfiles.includes(`flask${sep}__init__.py`),
-      "flask isn't packaged on its own"
-    );
-    t.end();
-  },
-  { skip: !hasPython(3) }
-);
+test('py3.7 can package flask with zip option', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { zip: 'true', pythonBin: getPythonBin(3) } });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(
+    zipfiles.includes('.requirements.zip'),
+    'zipped requirements are packaged'
+  );
+  t.true(zipfiles.includes(`unzip_requirements.py`), 'unzip util is packaged');
+  t.false(
+    zipfiles.includes(`flask${sep}__init__.py`),
+    "flask isn't packaged on its own"
+  );
+  t.end();
+});
 
-test(
-  'py3.7 can package flask with slim option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { slim: 'true', pythonBin: getPythonBin(3) } });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      'no pyc files packaged'
-    );
-    t.true(
-      zipfiles.filter((filename) => filename.endsWith('__main__.py')).length >
-        0,
-      '__main__.py files are packaged'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3) }
-);
+test('py3.7 can package flask with slim option', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { slim: 'true', pythonBin: getPythonBin(3) } });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.deepEqual(
+    zipfiles.filter((filename) => filename.endsWith('.pyc')),
+    [],
+    'no pyc files packaged'
+  );
+  t.true(
+    zipfiles.filter((filename) => filename.endsWith('__main__.py')).length > 0,
+    '__main__.py files are packaged'
+  );
+  t.end();
+});
 
-test(
-  'py3.7 can package flask with slim & slimPatterns options',
-  async (t) => {
-    process.chdir('tests/base');
-    copySync('_slimPatterns.yml', 'slimPatterns.yml');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { slim: 'true' } });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      'no pyc files packaged'
-    );
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('__main__.py')),
-      [],
-      '__main__.py files are NOT packaged'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+test('py3.7 can package flask with slim & slimPatterns options', async (t) => {
+  process.chdir('tests/base');
+  copySync('_slimPatterns.yml', 'slimPatterns.yml');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { slim: 'true' } });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.deepEqual(
+    zipfiles.filter((filename) => filename.endsWith('.pyc')),
+    [],
+    'no pyc files packaged'
+  );
+  t.deepEqual(
+    zipfiles.filter((filename) => filename.endsWith('__main__.py')),
+    [],
+    '__main__.py files are NOT packaged'
+  );
+  t.end();
+});
 
-test(
-  "py3.7 doesn't package bottle with noDeploy option",
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    perl([
-      '-p',
-      '-i.bak',
-      '-e',
-      's/(pythonRequirements:$)/\\1\\n    noDeploy: [bottle]/',
-      'serverless.yml',
-    ]);
-    sls(['package'], { env: { pythonBin: getPythonBin(3) } });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.false(zipfiles.includes(`bottle.py`), 'bottle is NOT packaged');
-    t.end();
-  },
-  { skip: !hasPython(3) }
-);
+test("py3.7 doesn't package bottle with noDeploy option", async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  perl([
+    '-p',
+    '-i.bak',
+    '-e',
+    's/(pythonRequirements:$)/\\1\\n    noDeploy: [bottle]/',
+    'serverless.yml',
+  ]);
+  sls(['package'], { env: { pythonBin: getPythonBin(3) } });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.false(zipfiles.includes(`bottle.py`), 'bottle is NOT packaged');
+  t.end();
+});
 
-test(
-  'py3.7 can package boto3 with editable',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], {
-      env: {
-        fileName: 'requirements-w-editable.txt',
-        pythonBin: getPythonBin(3),
-      },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
-    t.true(
-      zipfiles.includes(`botocore${sep}__init__.py`),
-      'botocore is packaged'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3) }
-);
+test('py3.7 can package boto3 with editable', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], {
+    env: {
+      fileName: 'requirements-w-editable.txt',
+      pythonBin: getPythonBin(3),
+    },
+  });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
+  t.true(
+    zipfiles.includes(`botocore${sep}__init__.py`),
+    'botocore is packaged'
+  );
+  t.end();
+});
 
 test(
   'py3.7 can package flask with dockerizePip option',
@@ -446,7 +402,7 @@ test(
     t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
+  { skip: !canUseDocker() || brokenOn('win32') }
 );
 
 test(
@@ -470,7 +426,7 @@ test(
     );
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
+  { skip: !canUseDocker() || brokenOn('win32') }
 );
 
 test(
@@ -495,7 +451,7 @@ test(
     );
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
+  { skip: !canUseDocker() || brokenOn('win32') }
 );
 
 test(
@@ -527,7 +483,7 @@ test(
     );
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
+  { skip: !canUseDocker() || brokenOn('win32') }
 );
 
 test(
@@ -561,603 +517,245 @@ test(
     );
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
+  { skip: !canUseDocker() || brokenOn('win32') }
 );
 
-test(
-  'py2.7 can package flask with default options',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], {
-      env: { runtime: 'python2.7', pythonBin: getPythonBin(2) },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
-    t.end();
-  },
-  { skip: !hasPython(2) }
-);
+test('pipenv py3.7 can package flask with default options', async (t) => {
+  process.chdir('tests/pipenv');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: {} });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
+  t.false(
+    zipfiles.includes(`pytest${sep}__init__.py`),
+    'dev-package pytest is NOT packaged'
+  );
+  t.end();
+});
 
-test(
-  'py2.7 can package flask with slim option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], {
-      env: { runtime: 'python2.7', slim: 'true', pythonBin: getPythonBin(2) },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      'no pyc files packaged'
-    );
-    t.true(
-      zipfiles.filter((filename) => filename.endsWith('__main__.py')).length >
-        0,
-      '__main__.py files are packaged'
-    );
-    t.end();
-  },
-  { skip: !hasPython(2) }
-);
+test('pipenv py3.7 can package flask with slim option', async (t) => {
+  process.chdir('tests/pipenv');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { slim: 'true' } });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.deepEqual(
+    zipfiles.filter((filename) => filename.endsWith('.pyc')),
+    [],
+    'no pyc files packaged'
+  );
+  t.true(
+    zipfiles.filter((filename) => filename.endsWith('__main__.py')).length > 0,
+    '__main__.py files are packaged'
+  );
+  t.end();
+});
 
-test(
-  'py2.7 can package flask with zip option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], {
-      env: { runtime: 'python2.7', zip: 'true', pythonBin: getPythonBin(2) },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(
-      zipfiles.includes('.requirements.zip'),
-      'zipped requirements are packaged'
-    );
-    t.true(
-      zipfiles.includes(`unzip_requirements.py`),
-      'unzip util is packaged'
-    );
-    t.false(
-      zipfiles.includes(`flask${sep}__init__.py`),
-      "flask isn't packaged on its own"
-    );
-    t.end();
-  },
-  { skip: !hasPython(2) }
-);
+test('pipenv py3.7 can package flask with slim & slimPatterns options', async (t) => {
+  process.chdir('tests/pipenv');
 
-test(
-  'py2.7 can package flask with slim & dockerizePip & slimPatterns options',
-  async (t) => {
-    process.chdir('tests/base');
+  copySync('_slimPatterns.yml', 'slimPatterns.yml');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { slim: 'true' } });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.deepEqual(
+    zipfiles.filter((filename) => filename.endsWith('.pyc')),
+    [],
+    'no pyc files packaged'
+  );
+  t.deepEqual(
+    zipfiles.filter((filename) => filename.endsWith('__main__.py')),
+    [],
+    '__main__.py files are NOT packaged'
+  );
+  t.end();
+});
 
-    copySync('_slimPatterns.yml', 'slimPatterns.yml');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], {
-      env: {
-        runtime: 'python2.7',
-        dockerizePip: 'true',
-        slim: 'true',
-        pythonBin: getPythonBin(2),
-      },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      '*.pyc files are packaged'
-    );
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('__main__.py')),
-      [],
-      '__main__.py files are NOT packaged'
-    );
-    t.end();
-  },
-  { skip: !canUseDocker() || !hasPython(2) || brokenOn('win32') }
-);
+test('pipenv py3.7 can package flask with zip option', async (t) => {
+  process.chdir('tests/pipenv');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { zip: 'true', pythonBin: getPythonBin(3) } });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(
+    zipfiles.includes('.requirements.zip'),
+    'zipped requirements are packaged'
+  );
+  t.true(zipfiles.includes(`unzip_requirements.py`), 'unzip util is packaged');
+  t.false(
+    zipfiles.includes(`flask${sep}__init__.py`),
+    "flask isn't packaged on its own"
+  );
+  t.end();
+});
 
-test(
-  "py2.7 doesn't package bottle with noDeploy option",
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    perl([
-      '-p',
-      '-i.bak',
-      '-e',
-      's/(pythonRequirements:$)/\\1\\n    noDeploy: [bottle]/',
-      'serverless.yml',
-    ]);
-    sls(['package'], {
-      env: { runtime: 'python2.7', pythonBin: getPythonBin(2) },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.false(zipfiles.includes(`bottle.py`), 'bottle is NOT packaged');
-    t.end();
-  },
-  { skip: !hasPython(2) }
-);
+test("pipenv py3.7 doesn't package bottle with noDeploy option", async (t) => {
+  process.chdir('tests/pipenv');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  perl([
+    '-p',
+    '-i.bak',
+    '-e',
+    's/(pythonRequirements:$)/\\1\\n    noDeploy: [bottle]/',
+    'serverless.yml',
+  ]);
+  sls(['package'], { env: {} });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.false(zipfiles.includes(`bottle.py`), 'bottle is NOT packaged');
+  t.end();
+});
 
-test(
-  'py2.7 can package flask with zip & dockerizePip option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], {
-      env: {
-        runtime: 'python2.7',
-        dockerizePip: 'true',
-        zip: 'true',
-        pythonBin: getPythonBin(2),
-      },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    const zippedReqs = await listRequirementsZipFiles(
-      '.serverless/sls-py-req-test.zip'
-    );
-    t.true(
-      zipfiles.includes('.requirements.zip'),
-      'zipped requirements are packaged'
-    );
-    t.true(
-      zipfiles.includes(`unzip_requirements.py`),
-      'unzip util is packaged'
-    );
-    t.false(
-      zipfiles.includes(`flask${sep}__init__.py`),
-      "flask isn't packaged on its own"
-    );
-    t.true(
-      zippedReqs.includes(`flask/__init__.py`),
-      'flask is packaged in the .requirements.zip file'
-    );
-    t.end();
-  },
-  { skip: !canUseDocker() || !hasPython(2) || brokenOn('win32') }
-);
+test('non build pyproject.toml uses requirements.txt', async (t) => {
+  process.chdir('tests/non_build_pyproject');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: {} });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
+  t.end();
+});
 
-test(
-  'py2.7 can package flask with zip & slim & dockerizePip option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], {
-      env: {
-        runtime: 'python2.7',
-        dockerizePip: 'true',
-        zip: 'true',
-        slim: 'true',
-        pythonBin: getPythonBin(2),
-      },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    const zippedReqs = await listRequirementsZipFiles(
-      '.serverless/sls-py-req-test.zip'
-    );
-    t.true(
-      zipfiles.includes('.requirements.zip'),
-      'zipped requirements are packaged'
-    );
-    t.true(
-      zipfiles.includes(`unzip_requirements.py`),
-      'unzip util is packaged'
-    );
-    t.false(
-      zipfiles.includes(`flask${sep}__init__.py`),
-      "flask isn't packaged on its own"
-    );
-    t.true(
-      zippedReqs.includes(`flask/__init__.py`),
-      'flask is packaged in the .requirements.zip file'
-    );
-    t.end();
-  },
-  { skip: !canUseDocker() || !hasPython(2) || brokenOn('win32') }
-);
+test('non poetry pyproject.toml without requirements.txt packages handler only', async (t) => {
+  process.chdir('tests/non_poetry_pyproject');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: {} });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`handler.py`), 'handler is packaged');
+  t.end();
+});
 
-test(
-  'py2.7 can package flask with dockerizePip option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], {
-      env: {
-        runtime: 'python2.7',
-        dockerizePip: 'true',
-        pythonBin: getPythonBin(2),
-      },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
-    t.end();
-  },
-  { skip: !canUseDocker() || !hasPython(2) || brokenOn('win32') }
-);
+test('poetry py3.7 can package flask with default options', async (t) => {
+  process.chdir('tests/poetry');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: {} });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.true(zipfiles.includes(`bottle.py`), 'bottle is packaged');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
+  t.end();
+});
 
-test(
-  'py2.7 can package flask with slim & dockerizePip option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], {
-      env: {
-        runtime: 'python2.7',
-        dockerizePip: 'true',
-        slim: 'true',
-        pythonBin: getPythonBin(2),
-      },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      '*.pyc files are NOT packaged'
-    );
-    t.true(
-      zipfiles.filter((filename) => filename.endsWith('__main__.py')).length >
-        0,
-      '__main__.py files are packaged'
-    );
-    t.end();
-  },
-  { skip: !canUseDocker() || !hasPython(2) || brokenOn('win32') }
-);
+test('poetry py3.7 can package flask with slim option', async (t) => {
+  process.chdir('tests/poetry');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { slim: 'true' } });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.deepEqual(
+    zipfiles.filter((filename) => filename.endsWith('.pyc')),
+    [],
+    'no pyc files packaged'
+  );
+  t.true(
+    zipfiles.filter((filename) => filename.endsWith('__main__.py')).length > 0,
+    '__main__.py files are packaged'
+  );
+  t.end();
+});
 
-test(
-  'py2.7 can package flask with slim & dockerizePip & slimPatterns options',
-  async (t) => {
-    process.chdir('tests/base');
+test('poetry py3.7 can package flask with slim & slimPatterns options', async (t) => {
+  process.chdir('tests/poetry');
 
-    copySync('_slimPatterns.yml', 'slimPatterns.yml');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], {
-      env: {
-        runtime: 'python2.7',
-        dockerizePip: 'true',
-        slim: 'true',
-        pythonBin: getPythonBin(2),
-      },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      '*.pyc files are packaged'
-    );
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('__main__.py')),
-      [],
-      '__main__.py files are NOT packaged'
-    );
-    t.end();
-  },
-  { skip: !canUseDocker() || !hasPython(2) || brokenOn('win32') }
-);
+  copySync('_slimPatterns.yml', 'slimPatterns.yml');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { slim: 'true' } });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.deepEqual(
+    zipfiles.filter((filename) => filename.endsWith('.pyc')),
+    [],
+    'no pyc files packaged'
+  );
+  t.deepEqual(
+    zipfiles.filter((filename) => filename.endsWith('__main__.py')),
+    [],
+    '__main__.py files are NOT packaged'
+  );
+  t.end();
+});
 
-test(
-  'pipenv py3.7 can package flask with default options',
-  async (t) => {
-    process.chdir('tests/pipenv');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: {} });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
-    t.false(
-      zipfiles.includes(`pytest${sep}__init__.py`),
-      'dev-package pytest is NOT packaged'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+test('poetry py3.7 can package flask with zip option', async (t) => {
+  process.chdir('tests/poetry');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { zip: 'true', pythonBin: getPythonBin(3) } });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(
+    zipfiles.includes('.requirements.zip'),
+    'zipped requirements are packaged'
+  );
+  t.true(zipfiles.includes(`unzip_requirements.py`), 'unzip util is packaged');
+  t.false(
+    zipfiles.includes(`flask${sep}__init__.py`),
+    "flask isn't packaged on its own"
+  );
+  t.end();
+});
 
-test(
-  'pipenv py3.7 can package flask with slim option',
-  async (t) => {
-    process.chdir('tests/pipenv');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { slim: 'true' } });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      'no pyc files packaged'
-    );
-    t.true(
-      zipfiles.filter((filename) => filename.endsWith('__main__.py')).length >
-        0,
-      '__main__.py files are packaged'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+test("poetry py3.7 doesn't package bottle with noDeploy option", async (t) => {
+  process.chdir('tests/poetry');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  perl([
+    '-p',
+    '-i.bak',
+    '-e',
+    's/(pythonRequirements:$)/\\1\\n    noDeploy: [bottle]/',
+    'serverless.yml',
+  ]);
+  sls(['package'], { env: {} });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.false(zipfiles.includes(`bottle.py`), 'bottle is NOT packaged');
+  t.end();
+});
 
-test(
-  'pipenv py3.7 can package flask with slim & slimPatterns options',
-  async (t) => {
-    process.chdir('tests/pipenv');
+test('py3.7 can package flask with zip option and no explicit include', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  perl(['-p', '-i.bak', '-e', 's/include://', 'serverless.yml']);
+  perl(['-p', '-i.bak', '-e', 's/^.*handler.py.*$//', 'serverless.yml']);
+  sls(['package'], { env: { zip: 'true' } });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(
+    zipfiles.includes('.requirements.zip'),
+    'zipped requirements are packaged'
+  );
+  t.true(zipfiles.includes(`unzip_requirements.py`), 'unzip util is packaged');
+  t.false(
+    zipfiles.includes(`flask${sep}__init__.py`),
+    "flask isn't packaged on its own"
+  );
+  t.end();
+});
 
-    copySync('_slimPatterns.yml', 'slimPatterns.yml');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { slim: 'true' } });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      'no pyc files packaged'
-    );
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('__main__.py')),
-      [],
-      '__main__.py files are NOT packaged'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
-
-test(
-  'pipenv py3.7 can package flask with zip option',
-  async (t) => {
-    process.chdir('tests/pipenv');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { zip: 'true', pythonBin: getPythonBin(3) } });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(
-      zipfiles.includes('.requirements.zip'),
-      'zipped requirements are packaged'
-    );
-    t.true(
-      zipfiles.includes(`unzip_requirements.py`),
-      'unzip util is packaged'
-    );
-    t.false(
-      zipfiles.includes(`flask${sep}__init__.py`),
-      "flask isn't packaged on its own"
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
-
-test(
-  "pipenv py3.7 doesn't package bottle with noDeploy option",
-  async (t) => {
-    process.chdir('tests/pipenv');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    perl([
-      '-p',
-      '-i.bak',
-      '-e',
-      's/(pythonRequirements:$)/\\1\\n    noDeploy: [bottle]/',
-      'serverless.yml',
-    ]);
-    sls(['package'], { env: {} });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.false(zipfiles.includes(`bottle.py`), 'bottle is NOT packaged');
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
-
-test(
-  'non build pyproject.toml uses requirements.txt',
-  async (t) => {
-    process.chdir('tests/non_build_pyproject');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: {} });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
-
-test(
-  'non poetry pyproject.toml without requirements.txt packages handler only',
-  async (t) => {
-    process.chdir('tests/non_poetry_pyproject');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: {} });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`handler.py`), 'handler is packaged');
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
-
-test(
-  'poetry py3.7 can package flask with default options',
-  async (t) => {
-    process.chdir('tests/poetry');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: {} });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(zipfiles.includes(`bottle.py`), 'bottle is packaged');
-    t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
-
-test(
-  'poetry py3.7 can package flask with slim option',
-  async (t) => {
-    process.chdir('tests/poetry');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { slim: 'true' } });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      'no pyc files packaged'
-    );
-    t.true(
-      zipfiles.filter((filename) => filename.endsWith('__main__.py')).length >
-        0,
-      '__main__.py files are packaged'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
-
-test(
-  'poetry py3.7 can package flask with slim & slimPatterns options',
-  async (t) => {
-    process.chdir('tests/poetry');
-
-    copySync('_slimPatterns.yml', 'slimPatterns.yml');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { slim: 'true' } });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      'no pyc files packaged'
-    );
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('__main__.py')),
-      [],
-      '__main__.py files are NOT packaged'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
-
-test(
-  'poetry py3.7 can package flask with zip option',
-  async (t) => {
-    process.chdir('tests/poetry');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { zip: 'true', pythonBin: getPythonBin(3) } });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(
-      zipfiles.includes('.requirements.zip'),
-      'zipped requirements are packaged'
-    );
-    t.true(
-      zipfiles.includes(`unzip_requirements.py`),
-      'unzip util is packaged'
-    );
-    t.false(
-      zipfiles.includes(`flask${sep}__init__.py`),
-      "flask isn't packaged on its own"
-    );
-    t.end();
-  },
-  { skip: !hasPython(3) }
-);
-
-test(
-  "poetry py3.7 doesn't package bottle with noDeploy option",
-  async (t) => {
-    process.chdir('tests/poetry');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    perl([
-      '-p',
-      '-i.bak',
-      '-e',
-      's/(pythonRequirements:$)/\\1\\n    noDeploy: [bottle]/',
-      'serverless.yml',
-    ]);
-    sls(['package'], { env: {} });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.false(zipfiles.includes(`bottle.py`), 'bottle is NOT packaged');
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
-
-test(
-  'py3.7 can package flask with zip option and no explicit include',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    perl(['-p', '-i.bak', '-e', 's/include://', 'serverless.yml']);
-    perl(['-p', '-i.bak', '-e', 's/^.*handler.py.*$//', 'serverless.yml']);
-    sls(['package'], { env: { zip: 'true' } });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(
-      zipfiles.includes('.requirements.zip'),
-      'zipped requirements are packaged'
-    );
-    t.true(
-      zipfiles.includes(`unzip_requirements.py`),
-      'unzip util is packaged'
-    );
-    t.false(
-      zipfiles.includes(`flask${sep}__init__.py`),
-      "flask isn't packaged on its own"
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
-
-test(
-  'py3.7 can package lambda-decorators using vendor option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { vendor: './vendor' } });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
-    t.true(
-      zipfiles.includes(`lambda_decorators.py`),
-      'lambda_decorators.py is packaged'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+test('py3.7 can package lambda-decorators using vendor option', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { vendor: './vendor' } });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
+  t.true(
+    zipfiles.includes(`lambda_decorators.py`),
+    'lambda_decorators.py is packaged'
+  );
+  t.end();
+});
 
 test(
   "Don't nuke execute perms",
@@ -1204,24 +802,20 @@ test(
 
     t.end();
   },
-  { skip: process.platform === 'win32' || !hasPython(3.7) }
+  { skip: process.platform === 'win32' }
 );
 
-test(
-  'py3.7 can package flask in a project with a space in it',
-  async (t) => {
-    copySync('tests/base', 'tests/base with a space');
-    process.chdir('tests/base with a space');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: {} });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+test('py3.7 can package flask in a project with a space in it', async (t) => {
+  copySync('tests/base', 'tests/base with a space');
+  process.chdir('tests/base with a space');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: {} });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
+  t.end();
+});
 
 test(
   'py3.7 can package flask in a project with a space in it with docker',
@@ -1236,103 +830,82 @@ test(
     t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
+  { skip: !canUseDocker() || brokenOn('win32') }
 );
 
-test(
-  'py3.7 supports custom file name with fileName option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    writeFileSync('puck', 'requests');
-    npm(['i', path]);
-    sls(['package'], { env: { fileName: 'puck' } });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(
-      zipfiles.includes(`requests${sep}__init__.py`),
-      'requests is packaged'
-    );
-    t.false(
-      zipfiles.includes(`flask${sep}__init__.py`),
-      'flask is NOT packaged'
-    );
-    t.false(
-      zipfiles.includes(`boto3${sep}__init__.py`),
-      'boto3 is NOT packaged'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+test('py3.7 supports custom file name with fileName option', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  writeFileSync('puck', 'requests');
+  npm(['i', path]);
+  sls(['package'], { env: { fileName: 'puck' } });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(
+    zipfiles.includes(`requests${sep}__init__.py`),
+    'requests is packaged'
+  );
+  t.false(zipfiles.includes(`flask${sep}__init__.py`), 'flask is NOT packaged');
+  t.false(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is NOT packaged');
+  t.end();
+});
 
-test(
-  "py3.7 doesn't package bottle with zip option",
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    perl([
-      '-p',
-      '-i.bak',
-      '-e',
-      's/(pythonRequirements:$)/\\1\\n    noDeploy: [bottle]/',
-      'serverless.yml',
-    ]);
-    sls(['package'], { env: { zip: 'true', pythonBin: getPythonBin(3) } });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    const zippedReqs = await listRequirementsZipFiles(
-      '.serverless/sls-py-req-test.zip'
-    );
-    t.true(
-      zipfiles.includes('.requirements.zip'),
-      'zipped requirements are packaged'
-    );
-    t.true(
-      zipfiles.includes(`unzip_requirements.py`),
-      'unzip util is packaged'
-    );
-    t.false(
-      zipfiles.includes(`flask${sep}__init__.py`),
-      "flask isn't packaged on its own"
-    );
-    t.true(
-      zippedReqs.includes(`flask/__init__.py`),
-      'flask is packaged in the .requirements.zip file'
-    );
-    t.false(
-      zippedReqs.includes(`bottle.py`),
-      'bottle is NOT packaged in the .requirements.zip file'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3) }
-);
+test("py3.7 doesn't package bottle with zip option", async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  perl([
+    '-p',
+    '-i.bak',
+    '-e',
+    's/(pythonRequirements:$)/\\1\\n    noDeploy: [bottle]/',
+    'serverless.yml',
+  ]);
+  sls(['package'], { env: { zip: 'true', pythonBin: getPythonBin(3) } });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  const zippedReqs = await listRequirementsZipFiles(
+    '.serverless/sls-py-req-test.zip'
+  );
+  t.true(
+    zipfiles.includes('.requirements.zip'),
+    'zipped requirements are packaged'
+  );
+  t.true(zipfiles.includes(`unzip_requirements.py`), 'unzip util is packaged');
+  t.false(
+    zipfiles.includes(`flask${sep}__init__.py`),
+    "flask isn't packaged on its own"
+  );
+  t.true(
+    zippedReqs.includes(`flask/__init__.py`),
+    'flask is packaged in the .requirements.zip file'
+  );
+  t.false(
+    zippedReqs.includes(`bottle.py`),
+    'bottle is NOT packaged in the .requirements.zip file'
+  );
+  t.end();
+});
 
-test(
-  'py3.7 can package flask with slim, slimPatterns & slimPatternsAppendDefaults=false options',
-  async (t) => {
-    process.chdir('tests/base');
-    copySync('_slimPatterns.yml', 'slimPatterns.yml');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], {
-      env: { slim: 'true', slimPatternsAppendDefaults: 'false' },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(
-      zipfiles.filter((filename) => filename.endsWith('.pyc')).length >= 1,
-      'pyc files are packaged'
-    );
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('__main__.py')),
-      [],
-      '__main__.py files are NOT packaged'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+test('py3.7 can package flask with slim, slimPatterns & slimPatternsAppendDefaults=false options', async (t) => {
+  process.chdir('tests/base');
+  copySync('_slimPatterns.yml', 'slimPatterns.yml');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], {
+    env: { slim: 'true', slimPatternsAppendDefaults: 'false' },
+  });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.true(
+    zipfiles.filter((filename) => filename.endsWith('.pyc')).length >= 1,
+    'pyc files are packaged'
+  );
+  t.deepEqual(
+    zipfiles.filter((filename) => filename.endsWith('__main__.py')),
+    [],
+    '__main__.py files are NOT packaged'
+  );
+  t.end();
+});
 
 test(
   'py3.7 can package flask with slim & dockerizePip & slimPatterns & slimPatternsAppendDefaults=false options',
@@ -1361,645 +934,366 @@ test(
     );
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
+  { skip: !canUseDocker() || brokenOn('win32') }
 );
 
-test(
-  'py2.7 can package flask with slim & slimPatterns & slimPatternsAppendDefaults=false options',
-  async (t) => {
-    process.chdir('tests/base');
-    copySync('_slimPatterns.yml', 'slimPatterns.yml');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], {
-      env: {
-        runtime: 'python2.7',
-        slim: 'true',
-        slimPatternsAppendDefaults: 'false',
-      },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(
-      zipfiles.filter((filename) => filename.endsWith('.pyc')).length >= 1,
-      'pyc files are packaged'
-    );
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('__main__.py')),
-      [],
-      '__main__.py files are NOT packaged'
-    );
-    t.end();
-  },
-  { skip: !hasPython(2.7) || brokenOn('win32') }
-);
+test('pipenv py3.7 can package flask with slim & slimPatterns & slimPatternsAppendDefaults=false  option', async (t) => {
+  process.chdir('tests/pipenv');
+  copySync('_slimPatterns.yml', 'slimPatterns.yml');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
 
-test(
-  'py2.7 can package flask with slim & dockerizePip & slimPatterns & slimPatternsAppendDefaults=false options',
-  async (t) => {
-    process.chdir('tests/base');
-    copySync('_slimPatterns.yml', 'slimPatterns.yml');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], {
-      env: {
-        dockerizePip: 'true',
-        runtime: 'python2.7',
-        slim: 'true',
-        slimPatternsAppendDefaults: 'false',
-      },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(
-      zipfiles.filter((filename) => filename.endsWith('.pyc')).length >= 1,
-      'pyc files are packaged'
-    );
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('__main__.py')),
-      [],
-      '__main__.py files are NOT packaged'
-    );
-    t.end();
-  },
-  { skip: !canUseDocker() || !hasPython(2.7) || brokenOn('win32') }
-);
+  sls(['package'], {
+    env: { slim: 'true', slimPatternsAppendDefaults: 'false' },
+  });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.true(
+    zipfiles.filter((filename) => filename.endsWith('.pyc')).length >= 1,
+    'pyc files are packaged'
+  );
+  t.deepEqual(
+    zipfiles.filter((filename) => filename.endsWith('__main__.py')),
+    [],
+    '__main__.py files are NOT packaged'
+  );
+  t.end();
+});
 
-test(
-  'pipenv py3.7 can package flask with slim & slimPatterns & slimPatternsAppendDefaults=false  option',
-  async (t) => {
-    process.chdir('tests/pipenv');
-    copySync('_slimPatterns.yml', 'slimPatterns.yml');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
+test('poetry py3.7 can package flask with slim & slimPatterns & slimPatternsAppendDefaults=false  option', async (t) => {
+  process.chdir('tests/poetry');
+  copySync('_slimPatterns.yml', 'slimPatterns.yml');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
 
-    sls(['package'], {
-      env: { slim: 'true', slimPatternsAppendDefaults: 'false' },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(
-      zipfiles.filter((filename) => filename.endsWith('.pyc')).length >= 1,
-      'pyc files are packaged'
-    );
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('__main__.py')),
-      [],
-      '__main__.py files are NOT packaged'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+  sls(['package'], {
+    env: { slim: 'true', slimPatternsAppendDefaults: 'false' },
+  });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.true(
+    zipfiles.filter((filename) => filename.endsWith('.pyc')).length >= 1,
+    'pyc files are packaged'
+  );
+  t.deepEqual(
+    zipfiles.filter((filename) => filename.endsWith('__main__.py')),
+    [],
+    '__main__.py files are NOT packaged'
+  );
+  t.end();
+});
 
-test(
-  'poetry py3.7 can package flask with slim & slimPatterns & slimPatternsAppendDefaults=false  option',
-  async (t) => {
-    process.chdir('tests/poetry');
-    copySync('_slimPatterns.yml', 'slimPatterns.yml');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
+test('poetry py3.7 can package flask with package individually option', async (t) => {
+  process.chdir('tests/poetry_individually');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
 
-    sls(['package'], {
-      env: { slim: 'true', slimPatternsAppendDefaults: 'false' },
-    });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(
-      zipfiles.filter((filename) => filename.endsWith('.pyc')).length >= 1,
-      'pyc files are packaged'
-    );
-    t.deepEqual(
-      zipfiles.filter((filename) => filename.endsWith('__main__.py')),
-      [],
-      '__main__.py files are NOT packaged'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+  sls(['package'], { env: {} });
+  const zipfiles = await listZipFiles(
+    '.serverless/module1-sls-py-req-test-dev-hello.zip'
+  );
+  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
+  t.true(zipfiles.includes(`bottle.py`), 'bottle is packaged');
+  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
+  t.end();
+});
 
-test(
-  'poetry py3.7 can package flask with package individually option',
-  async (t) => {
-    process.chdir('tests/poetry_individually');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
+test('py3.7 can package flask with package individually option', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { individually: 'true' } });
+  const zipfiles_hello = await listZipFiles('.serverless/hello.zip');
+  t.false(
+    zipfiles_hello.includes(`fn2${sep}__init__.py`),
+    'fn2 is NOT packaged in function hello'
+  );
+  t.true(
+    zipfiles_hello.includes('handler.py'),
+    'handler.py is packaged in function hello'
+  );
+  t.false(
+    zipfiles_hello.includes(`dataclasses.py`),
+    'dataclasses is NOT packaged in function hello'
+  );
+  t.true(
+    zipfiles_hello.includes(`flask${sep}__init__.py`),
+    'flask is packaged in function hello'
+  );
 
-    sls(['package'], { env: {} });
-    const zipfiles = await listZipFiles(
-      '.serverless/module1-sls-py-req-test-dev-hello.zip'
-    );
-    t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged');
-    t.true(zipfiles.includes(`bottle.py`), 'bottle is packaged');
-    t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged');
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+  const zipfiles_hello2 = await listZipFiles('.serverless/hello2.zip');
+  t.false(
+    zipfiles_hello2.includes(`fn2${sep}__init__.py`),
+    'fn2 is NOT packaged in function hello2'
+  );
+  t.true(
+    zipfiles_hello2.includes('handler.py'),
+    'handler.py is packaged in function hello2'
+  );
+  t.false(
+    zipfiles_hello2.includes(`dataclasses.py`),
+    'dataclasses is NOT packaged in function hello2'
+  );
+  t.true(
+    zipfiles_hello2.includes(`flask${sep}__init__.py`),
+    'flask is packaged in function hello2'
+  );
 
-test(
-  'py3.7 can package flask with package individually option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { individually: 'true' } });
-    const zipfiles_hello = await listZipFiles('.serverless/hello.zip');
-    t.false(
-      zipfiles_hello.includes(`fn2${sep}__init__.py`),
-      'fn2 is NOT packaged in function hello'
-    );
-    t.true(
-      zipfiles_hello.includes('handler.py'),
-      'handler.py is packaged in function hello'
-    );
-    t.false(
-      zipfiles_hello.includes(`dataclasses.py`),
-      'dataclasses is NOT packaged in function hello'
-    );
-    t.true(
-      zipfiles_hello.includes(`flask${sep}__init__.py`),
-      'flask is packaged in function hello'
-    );
+  const zipfiles_hello3 = await listZipFiles('.serverless/hello3.zip');
+  t.false(
+    zipfiles_hello3.includes(`fn2${sep}__init__.py`),
+    'fn2 is NOT packaged in function hello3'
+  );
+  t.true(
+    zipfiles_hello3.includes('handler.py'),
+    'handler.py is packaged in function hello3'
+  );
+  t.false(
+    zipfiles_hello3.includes(`dataclasses.py`),
+    'dataclasses is NOT packaged in function hello3'
+  );
+  t.false(
+    zipfiles_hello3.includes(`flask${sep}__init__.py`),
+    'flask is NOT packaged in function hello3'
+  );
 
-    const zipfiles_hello2 = await listZipFiles('.serverless/hello2.zip');
-    t.false(
-      zipfiles_hello2.includes(`fn2${sep}__init__.py`),
-      'fn2 is NOT packaged in function hello2'
-    );
-    t.true(
-      zipfiles_hello2.includes('handler.py'),
-      'handler.py is packaged in function hello2'
-    );
-    t.false(
-      zipfiles_hello2.includes(`dataclasses.py`),
-      'dataclasses is NOT packaged in function hello2'
-    );
-    t.true(
-      zipfiles_hello2.includes(`flask${sep}__init__.py`),
-      'flask is packaged in function hello2'
-    );
+  const zipfiles_hello4 = await listZipFiles(
+    '.serverless/fn2-sls-py-req-test-dev-hello4.zip'
+  );
+  t.false(
+    zipfiles_hello4.includes(`fn2${sep}__init__.py`),
+    'fn2 is NOT packaged in function hello4'
+  );
+  t.true(
+    zipfiles_hello4.includes('fn2_handler.py'),
+    'fn2_handler is packaged in the zip-root in function hello4'
+  );
+  t.true(
+    zipfiles_hello4.includes(`dataclasses.py`),
+    'dataclasses is packaged in function hello4'
+  );
+  t.false(
+    zipfiles_hello4.includes(`flask${sep}__init__.py`),
+    'flask is NOT packaged in function hello4'
+  );
 
-    const zipfiles_hello3 = await listZipFiles('.serverless/hello3.zip');
-    t.false(
-      zipfiles_hello3.includes(`fn2${sep}__init__.py`),
-      'fn2 is NOT packaged in function hello3'
-    );
-    t.true(
-      zipfiles_hello3.includes('handler.py'),
-      'handler.py is packaged in function hello3'
-    );
-    t.false(
-      zipfiles_hello3.includes(`dataclasses.py`),
-      'dataclasses is NOT packaged in function hello3'
-    );
-    t.false(
-      zipfiles_hello3.includes(`flask${sep}__init__.py`),
-      'flask is NOT packaged in function hello3'
-    );
+  t.end();
+});
 
-    const zipfiles_hello4 = await listZipFiles(
-      '.serverless/fn2-sls-py-req-test-dev-hello4.zip'
-    );
-    t.false(
-      zipfiles_hello4.includes(`fn2${sep}__init__.py`),
-      'fn2 is NOT packaged in function hello4'
-    );
-    t.true(
-      zipfiles_hello4.includes('fn2_handler.py'),
-      'fn2_handler is packaged in the zip-root in function hello4'
-    );
-    t.true(
-      zipfiles_hello4.includes(`dataclasses.py`),
-      'dataclasses is packaged in function hello4'
-    );
-    t.false(
-      zipfiles_hello4.includes(`flask${sep}__init__.py`),
-      'flask is NOT packaged in function hello4'
-    );
+test('py3.7 can package flask with package individually & slim option', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { individually: 'true', slim: 'true' } });
+  const zipfiles_hello = await listZipFiles('.serverless/hello.zip');
+  t.true(
+    zipfiles_hello.includes('handler.py'),
+    'handler.py is packaged in function hello'
+  );
+  t.deepEqual(
+    zipfiles_hello.filter((filename) => filename.endsWith('.pyc')),
+    [],
+    'no pyc files packaged in function hello'
+  );
+  t.true(
+    zipfiles_hello.includes(`flask${sep}__init__.py`),
+    'flask is packaged in function hello'
+  );
+  t.false(
+    zipfiles_hello.includes(`dataclasses.py`),
+    'dataclasses is NOT packaged in function hello'
+  );
 
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+  const zipfiles_hello2 = await listZipFiles('.serverless/hello2.zip');
+  t.true(
+    zipfiles_hello2.includes('handler.py'),
+    'handler.py is packaged in function hello2'
+  );
+  t.deepEqual(
+    zipfiles_hello2.filter((filename) => filename.endsWith('.pyc')),
+    [],
+    'no pyc files packaged in function hello2'
+  );
+  t.true(
+    zipfiles_hello2.includes(`flask${sep}__init__.py`),
+    'flask is packaged in function hello2'
+  );
+  t.false(
+    zipfiles_hello2.includes(`dataclasses.py`),
+    'dataclasses is NOT packaged in function hello2'
+  );
 
-test(
-  'py3.7 can package flask with package individually & slim option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { individually: 'true', slim: 'true' } });
-    const zipfiles_hello = await listZipFiles('.serverless/hello.zip');
-    t.true(
-      zipfiles_hello.includes('handler.py'),
-      'handler.py is packaged in function hello'
-    );
-    t.deepEqual(
-      zipfiles_hello.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      'no pyc files packaged in function hello'
-    );
-    t.true(
-      zipfiles_hello.includes(`flask${sep}__init__.py`),
-      'flask is packaged in function hello'
-    );
-    t.false(
-      zipfiles_hello.includes(`dataclasses.py`),
-      'dataclasses is NOT packaged in function hello'
-    );
+  const zipfiles_hello3 = await listZipFiles('.serverless/hello3.zip');
+  t.true(
+    zipfiles_hello3.includes('handler.py'),
+    'handler.py is packaged in function hello3'
+  );
+  t.deepEqual(
+    zipfiles_hello3.filter((filename) => filename.endsWith('.pyc')),
+    [],
+    'no pyc files packaged in function hello3'
+  );
+  t.false(
+    zipfiles_hello3.includes(`flask${sep}__init__.py`),
+    'flask is NOT packaged in function hello3'
+  );
 
-    const zipfiles_hello2 = await listZipFiles('.serverless/hello2.zip');
-    t.true(
-      zipfiles_hello2.includes('handler.py'),
-      'handler.py is packaged in function hello2'
-    );
-    t.deepEqual(
-      zipfiles_hello2.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      'no pyc files packaged in function hello2'
-    );
-    t.true(
-      zipfiles_hello2.includes(`flask${sep}__init__.py`),
-      'flask is packaged in function hello2'
-    );
-    t.false(
-      zipfiles_hello2.includes(`dataclasses.py`),
-      'dataclasses is NOT packaged in function hello2'
-    );
+  const zipfiles_hello4 = await listZipFiles(
+    '.serverless/fn2-sls-py-req-test-dev-hello4.zip'
+  );
+  t.true(
+    zipfiles_hello4.includes('fn2_handler.py'),
+    'fn2_handler is packaged in the zip-root in function hello4'
+  );
+  t.true(
+    zipfiles_hello4.includes(`dataclasses.py`),
+    'dataclasses is packaged in function hello4'
+  );
+  t.false(
+    zipfiles_hello4.includes(`flask${sep}__init__.py`),
+    'flask is NOT packaged in function hello4'
+  );
+  t.deepEqual(
+    zipfiles_hello4.filter((filename) => filename.endsWith('.pyc')),
+    [],
+    'no pyc files packaged in function hello4'
+  );
 
-    const zipfiles_hello3 = await listZipFiles('.serverless/hello3.zip');
-    t.true(
-      zipfiles_hello3.includes('handler.py'),
-      'handler.py is packaged in function hello3'
-    );
-    t.deepEqual(
-      zipfiles_hello3.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      'no pyc files packaged in function hello3'
-    );
-    t.false(
-      zipfiles_hello3.includes(`flask${sep}__init__.py`),
-      'flask is NOT packaged in function hello3'
-    );
+  t.end();
+});
 
-    const zipfiles_hello4 = await listZipFiles(
-      '.serverless/fn2-sls-py-req-test-dev-hello4.zip'
-    );
-    t.true(
-      zipfiles_hello4.includes('fn2_handler.py'),
-      'fn2_handler is packaged in the zip-root in function hello4'
-    );
-    t.true(
-      zipfiles_hello4.includes(`dataclasses.py`),
-      'dataclasses is packaged in function hello4'
-    );
-    t.false(
-      zipfiles_hello4.includes(`flask${sep}__init__.py`),
-      'flask is NOT packaged in function hello4'
-    );
-    t.deepEqual(
-      zipfiles_hello4.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      'no pyc files packaged in function hello4'
-    );
+test('py3.7 can package only requirements of module', async (t) => {
+  process.chdir('tests/individually');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: {} });
+  const zipfiles_hello = await listZipFiles(
+    '.serverless/module1-sls-py-req-test-indiv-dev-hello1.zip'
+  );
+  t.true(
+    zipfiles_hello.includes('handler1.py'),
+    'handler1.py is packaged at root level in function hello1'
+  );
+  t.false(
+    zipfiles_hello.includes('handler2.py'),
+    'handler2.py is NOT packaged at root level in function hello1'
+  );
+  t.true(
+    zipfiles_hello.includes(`pyaml${sep}__init__.py`),
+    'pyaml is packaged in function hello1'
+  );
+  t.true(
+    zipfiles_hello.includes(`boto3${sep}__init__.py`),
+    'boto3 is packaged in function hello1'
+  );
+  t.false(
+    zipfiles_hello.includes(`flask${sep}__init__.py`),
+    'flask is NOT packaged in function hello1'
+  );
 
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+  const zipfiles_hello2 = await listZipFiles(
+    '.serverless/module2-sls-py-req-test-indiv-dev-hello2.zip'
+  );
+  t.true(
+    zipfiles_hello2.includes('handler2.py'),
+    'handler2.py is packaged at root level in function hello2'
+  );
+  t.false(
+    zipfiles_hello2.includes('handler1.py'),
+    'handler1.py is NOT packaged at root level in function hello2'
+  );
+  t.false(
+    zipfiles_hello2.includes(`pyaml${sep}__init__.py`),
+    'pyaml is NOT packaged in function hello2'
+  );
+  t.false(
+    zipfiles_hello2.includes(`boto3${sep}__init__.py`),
+    'boto3 is NOT packaged in function hello2'
+  );
+  t.true(
+    zipfiles_hello2.includes(`flask${sep}__init__.py`),
+    'flask is packaged in function hello2'
+  );
 
-test(
-  'py2.7 can package flask with package individually option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { individually: 'true', runtime: 'python2.7' } });
-    const zipfiles_hello = await listZipFiles('.serverless/hello.zip');
-    t.true(
-      zipfiles_hello.includes('handler.py'),
-      'handler.py is packaged in function hello'
-    );
-    t.true(
-      zipfiles_hello.includes(`flask${sep}__init__.py`),
-      'flask is packaged in function hello'
-    );
-    t.false(
-      zipfiles_hello.includes(`dataclasses.py`),
-      'dataclasses is NOT packaged in function hello'
-    );
+  t.end();
+});
 
-    const zipfiles_hello2 = await listZipFiles('.serverless/hello2.zip');
-    t.true(
-      zipfiles_hello2.includes('handler.py'),
-      'handler.py is packaged in function hello2'
-    );
-    t.true(
-      zipfiles_hello2.includes(`flask${sep}__init__.py`),
-      'flask is packaged in function hello2'
-    );
-    t.false(
-      zipfiles_hello2.includes(`dataclasses.py`),
-      'dataclasses is NOT packaged in function hello2'
-    );
+test('py3.7 can package lambda-decorators using vendor and invidiually option', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { individually: 'true', vendor: './vendor' } });
+  const zipfiles_hello = await listZipFiles('.serverless/hello.zip');
+  t.true(
+    zipfiles_hello.includes('handler.py'),
+    'handler.py is packaged at root level in function hello'
+  );
+  t.true(
+    zipfiles_hello.includes(`flask${sep}__init__.py`),
+    'flask is packaged in function hello'
+  );
+  t.true(
+    zipfiles_hello.includes(`lambda_decorators.py`),
+    'lambda_decorators.py is packaged in function hello'
+  );
+  t.false(
+    zipfiles_hello.includes(`dataclasses.py`),
+    'dataclasses is NOT packaged in function hello'
+  );
 
-    const zipfiles_hello3 = await listZipFiles('.serverless/hello3.zip');
-    t.true(
-      zipfiles_hello3.includes('handler.py'),
-      'handler.py is packaged in function hello3'
-    );
-    t.false(
-      zipfiles_hello3.includes(`flask${sep}__init__.py`),
-      'flask is NOT packaged in function hello3'
-    );
-    t.false(
-      zipfiles_hello3.includes(`dataclasses.py`),
-      'dataclasses is NOT packaged in function hello3'
-    );
+  const zipfiles_hello2 = await listZipFiles('.serverless/hello2.zip');
+  t.true(
+    zipfiles_hello2.includes('handler.py'),
+    'handler.py is packaged at root level in function hello2'
+  );
+  t.true(
+    zipfiles_hello2.includes(`flask${sep}__init__.py`),
+    'flask is packaged in function hello2'
+  );
+  t.true(
+    zipfiles_hello2.includes(`lambda_decorators.py`),
+    'lambda_decorators.py is packaged in function hello2'
+  );
+  t.false(
+    zipfiles_hello2.includes(`dataclasses.py`),
+    'dataclasses is NOT packaged in function hello2'
+  );
 
-    const zipfiles_hello4 = await listZipFiles(
-      '.serverless/fn2-sls-py-req-test-dev-hello4.zip'
-    );
-    t.true(
-      zipfiles_hello4.includes('fn2_handler.py'),
-      'fn2_handler is packaged in the zip-root in function hello4'
-    );
-    t.true(
-      zipfiles_hello4.includes(`dataclasses.py`),
-      'dataclasses is packaged in function hello4'
-    );
-    t.false(
-      zipfiles_hello4.includes(`flask${sep}__init__.py`),
-      'flask is NOT packaged in function hello4'
-    );
+  const zipfiles_hello3 = await listZipFiles('.serverless/hello3.zip');
+  t.true(
+    zipfiles_hello3.includes('handler.py'),
+    'handler.py is packaged at root level in function hello3'
+  );
+  t.false(
+    zipfiles_hello3.includes(`flask${sep}__init__.py`),
+    'flask is NOT packaged in function hello3'
+  );
+  t.false(
+    zipfiles_hello3.includes(`lambda_decorators.py`),
+    'lambda_decorators.py is NOT packaged in function hello3'
+  );
+  t.false(
+    zipfiles_hello3.includes(`dataclasses.py`),
+    'dataclasses is NOT packaged in function hello3'
+  );
 
-    t.end();
-  },
-  { skip: !hasPython(2.7) }
-);
-
-test(
-  'py2.7 can package flask with package individually & slim option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], {
-      env: { individually: 'true', runtime: 'python2.7', slim: 'true' },
-    });
-    const zipfiles_hello = await listZipFiles('.serverless/hello.zip');
-    t.true(
-      zipfiles_hello.includes('handler.py'),
-      'handler.py is packaged in function hello'
-    );
-    t.deepEqual(
-      zipfiles_hello.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      'no pyc files packaged in function hello'
-    );
-    t.true(
-      zipfiles_hello.includes(`flask${sep}__init__.py`),
-      'flask is packaged in function hello'
-    );
-    t.false(
-      zipfiles_hello.includes(`dataclasses.py`),
-      'dataclasses is NOT packaged in function hello'
-    );
-
-    const zipfiles_hello2 = await listZipFiles('.serverless/hello2.zip');
-    t.true(
-      zipfiles_hello2.includes('handler.py'),
-      'handler.py is packaged in function hello2'
-    );
-    t.deepEqual(
-      zipfiles_hello2.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      'no pyc files packaged in function hello2'
-    );
-    t.true(
-      zipfiles_hello2.includes(`flask${sep}__init__.py`),
-      'flask is packaged in function hello2'
-    );
-    t.false(
-      zipfiles_hello2.includes(`dataclasses.py`),
-      'dataclasses is NOT packaged in function hello2'
-    );
-
-    const zipfiles_hello3 = await listZipFiles('.serverless/hello3.zip');
-    t.true(
-      zipfiles_hello3.includes('handler.py'),
-      'handler.py is packaged in function hello3'
-    );
-    t.deepEqual(
-      zipfiles_hello3.filter((filename) => filename.endsWith('.pyc')),
-      [],
-      'no pyc files packaged in function hello3'
-    );
-    t.false(
-      zipfiles_hello3.includes(`flask${sep}__init__.py`),
-      'flask is NOT packaged in function hello3'
-    );
-    t.false(
-      zipfiles_hello3.includes(`dataclasses.py`),
-      'dataclasses is NOT packaged in function hello3'
-    );
-
-    const zipfiles_hello4 = await listZipFiles(
-      '.serverless/fn2-sls-py-req-test-dev-hello4.zip'
-    );
-    t.true(
-      zipfiles_hello4.includes('fn2_handler.py'),
-      'fn2_handler is packaged in the zip-root in function hello4'
-    );
-    t.true(
-      zipfiles_hello4.includes(`dataclasses.py`),
-      'dataclasses is packaged in function hello4'
-    );
-    t.false(
-      zipfiles_hello4.includes(`flask${sep}__init__.py`),
-      'flask is NOT packaged in function hello4'
-    );
-
-    t.end();
-  },
-  { skip: !hasPython(2.7) }
-);
-
-test(
-  'py2.7 can ignore functions defined with `image`',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { individually: 'true', runtime: 'python2.7' } });
-    t.true(
-      pathExistsSync('.serverless/hello.zip'),
-      'function hello is packaged'
-    );
-    t.true(
-      pathExistsSync('.serverless/hello2.zip'),
-      'function hello2 is packaged'
-    );
-    t.true(
-      pathExistsSync('.serverless/hello3.zip'),
-      'function hello3 is packaged'
-    );
-    t.true(
-      pathExistsSync('.serverless/hello4.zip'),
-      'function hello4 is packaged'
-    );
-    t.false(
-      pathExistsSync('.serverless/hello5.zip'),
-      'function hello5 is not packaged'
-    );
-
-    t.end();
-  },
-  { skip: !hasPython(2.7) }
-);
-
-test(
-  'py3.7 can package only requirements of module',
-  async (t) => {
-    process.chdir('tests/individually');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: {} });
-    const zipfiles_hello = await listZipFiles(
-      '.serverless/module1-sls-py-req-test-indiv-dev-hello1.zip'
-    );
-    t.true(
-      zipfiles_hello.includes('handler1.py'),
-      'handler1.py is packaged at root level in function hello1'
-    );
-    t.false(
-      zipfiles_hello.includes('handler2.py'),
-      'handler2.py is NOT packaged at root level in function hello1'
-    );
-    t.true(
-      zipfiles_hello.includes(`pyaml${sep}__init__.py`),
-      'pyaml is packaged in function hello1'
-    );
-    t.true(
-      zipfiles_hello.includes(`boto3${sep}__init__.py`),
-      'boto3 is packaged in function hello1'
-    );
-    t.false(
-      zipfiles_hello.includes(`flask${sep}__init__.py`),
-      'flask is NOT packaged in function hello1'
-    );
-
-    const zipfiles_hello2 = await listZipFiles(
-      '.serverless/module2-sls-py-req-test-indiv-dev-hello2.zip'
-    );
-    t.true(
-      zipfiles_hello2.includes('handler2.py'),
-      'handler2.py is packaged at root level in function hello2'
-    );
-    t.false(
-      zipfiles_hello2.includes('handler1.py'),
-      'handler1.py is NOT packaged at root level in function hello2'
-    );
-    t.false(
-      zipfiles_hello2.includes(`pyaml${sep}__init__.py`),
-      'pyaml is NOT packaged in function hello2'
-    );
-    t.false(
-      zipfiles_hello2.includes(`boto3${sep}__init__.py`),
-      'boto3 is NOT packaged in function hello2'
-    );
-    t.true(
-      zipfiles_hello2.includes(`flask${sep}__init__.py`),
-      'flask is packaged in function hello2'
-    );
-
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
-
-test(
-  'py3.7 can package lambda-decorators using vendor and invidiually option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { individually: 'true', vendor: './vendor' } });
-    const zipfiles_hello = await listZipFiles('.serverless/hello.zip');
-    t.true(
-      zipfiles_hello.includes('handler.py'),
-      'handler.py is packaged at root level in function hello'
-    );
-    t.true(
-      zipfiles_hello.includes(`flask${sep}__init__.py`),
-      'flask is packaged in function hello'
-    );
-    t.true(
-      zipfiles_hello.includes(`lambda_decorators.py`),
-      'lambda_decorators.py is packaged in function hello'
-    );
-    t.false(
-      zipfiles_hello.includes(`dataclasses.py`),
-      'dataclasses is NOT packaged in function hello'
-    );
-
-    const zipfiles_hello2 = await listZipFiles('.serverless/hello2.zip');
-    t.true(
-      zipfiles_hello2.includes('handler.py'),
-      'handler.py is packaged at root level in function hello2'
-    );
-    t.true(
-      zipfiles_hello2.includes(`flask${sep}__init__.py`),
-      'flask is packaged in function hello2'
-    );
-    t.true(
-      zipfiles_hello2.includes(`lambda_decorators.py`),
-      'lambda_decorators.py is packaged in function hello2'
-    );
-    t.false(
-      zipfiles_hello2.includes(`dataclasses.py`),
-      'dataclasses is NOT packaged in function hello2'
-    );
-
-    const zipfiles_hello3 = await listZipFiles('.serverless/hello3.zip');
-    t.true(
-      zipfiles_hello3.includes('handler.py'),
-      'handler.py is packaged at root level in function hello3'
-    );
-    t.false(
-      zipfiles_hello3.includes(`flask${sep}__init__.py`),
-      'flask is NOT packaged in function hello3'
-    );
-    t.false(
-      zipfiles_hello3.includes(`lambda_decorators.py`),
-      'lambda_decorators.py is NOT packaged in function hello3'
-    );
-    t.false(
-      zipfiles_hello3.includes(`dataclasses.py`),
-      'dataclasses is NOT packaged in function hello3'
-    );
-
-    const zipfiles_hello4 = await listZipFiles(
-      '.serverless/fn2-sls-py-req-test-dev-hello4.zip'
-    );
-    t.true(
-      zipfiles_hello4.includes('fn2_handler.py'),
-      'fn2_handler is packaged in the zip-root in function hello4'
-    );
-    t.true(
-      zipfiles_hello4.includes(`dataclasses.py`),
-      'dataclasses is packaged in function hello4'
-    );
-    t.false(
-      zipfiles_hello4.includes(`flask${sep}__init__.py`),
-      'flask is NOT packaged in function hello4'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+  const zipfiles_hello4 = await listZipFiles(
+    '.serverless/fn2-sls-py-req-test-dev-hello4.zip'
+  );
+  t.true(
+    zipfiles_hello4.includes('fn2_handler.py'),
+    'fn2_handler is packaged in the zip-root in function hello4'
+  );
+  t.true(
+    zipfiles_hello4.includes(`dataclasses.py`),
+    'dataclasses is packaged in function hello4'
+  );
+  t.false(
+    zipfiles_hello4.includes(`flask${sep}__init__.py`),
+    'flask is NOT packaged in function hello4'
+  );
+  t.end();
+});
 
 test(
   "Don't nuke execute perms when using individually",
@@ -2037,7 +1331,7 @@ test(
 
     t.end();
   },
-  { skip: process.platform === 'win32' || !hasPython(3.7) }
+  { skip: process.platform === 'win32' }
 );
 
 test(
@@ -2076,41 +1370,33 @@ test(
 
     t.end();
   },
-  { skip: !canUseDocker() || process.platform === 'win32' || !hasPython(3.7) }
+  { skip: !canUseDocker() || process.platform === 'win32' }
 );
 
-test(
-  'py3.7 uses download cache by default option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: {} });
-    const cachepath = getUserCachePath();
-    t.true(
-      pathExistsSync(`${cachepath}${sep}downloadCacheslspyc${sep}http`),
-      'cache directory exists'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+test('py3.7 uses download cache by default option', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: {} });
+  const cachepath = getUserCachePath();
+  t.true(
+    pathExistsSync(`${cachepath}${sep}downloadCacheslspyc${sep}http`),
+    'cache directory exists'
+  );
+  t.end();
+});
 
-test(
-  'py3.7 uses download cache by default',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { cacheLocation: '.requirements-cache' } });
-    t.true(
-      pathExistsSync(`.requirements-cache${sep}downloadCacheslspyc${sep}http`),
-      'cache directory exists'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+test('py3.7 uses download cache by default', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { cacheLocation: '.requirements-cache' } });
+  t.true(
+    pathExistsSync(`.requirements-cache${sep}downloadCacheslspyc${sep}http`),
+    'cache directory exists'
+  );
+  t.end();
+});
 
 test(
   'py3.7 uses download cache with dockerizePip option',
@@ -2126,7 +1412,7 @@ test(
     );
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
+  { skip: !canUseDocker() || brokenOn('win32') }
 );
 
 test(
@@ -2144,33 +1430,29 @@ test(
     );
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
+  { skip: !canUseDocker() || brokenOn('win32') }
 );
 
-test(
-  'py3.7 uses static and download cache',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: {} });
-    const cachepath = getUserCachePath();
-    const cacheFolderHash = sha256Path('.serverless/requirements.txt');
-    const arch = 'x86_64';
-    t.true(
-      pathExistsSync(`${cachepath}${sep}downloadCacheslspyc${sep}http`),
-      'http exists in download-cache'
-    );
-    t.true(
-      pathExistsSync(
-        `${cachepath}${sep}${cacheFolderHash}_${arch}_slspyc${sep}flask`
-      ),
-      'flask exists in static-cache'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+test('py3.7 uses static and download cache', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: {} });
+  const cachepath = getUserCachePath();
+  const cacheFolderHash = sha256Path('.serverless/requirements.txt');
+  const arch = 'x86_64';
+  t.true(
+    pathExistsSync(`${cachepath}${sep}downloadCacheslspyc${sep}http`),
+    'http exists in download-cache'
+  );
+  t.true(
+    pathExistsSync(
+      `${cachepath}${sep}${cacheFolderHash}_${arch}_slspyc${sep}flask`
+    ),
+    'flask exists in static-cache'
+  );
+  t.end();
+});
 
 test(
   'py3.7 uses static and download cache with dockerizePip option',
@@ -2194,75 +1476,67 @@ test(
     );
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
+  { skip: !canUseDocker() || brokenOn('win32') }
 );
 
-test(
-  'py3.7 uses static cache',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: {} });
-    const cachepath = getUserCachePath();
-    const cacheFolderHash = sha256Path('.serverless/requirements.txt');
-    const arch = 'x86_64';
-    t.true(
-      pathExistsSync(
-        `${cachepath}${sep}${cacheFolderHash}_${arch}_slspyc${sep}flask`
-      ),
-      'flask exists in static-cache'
-    );
-    t.true(
-      pathExistsSync(
-        `${cachepath}${sep}${cacheFolderHash}_${arch}_slspyc${sep}.completed_requirements`
-      ),
-      '.completed_requirements exists in static-cache'
-    );
+test('py3.7 uses static cache', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: {} });
+  const cachepath = getUserCachePath();
+  const cacheFolderHash = sha256Path('.serverless/requirements.txt');
+  const arch = 'x86_64';
+  t.true(
+    pathExistsSync(
+      `${cachepath}${sep}${cacheFolderHash}_${arch}_slspyc${sep}flask`
+    ),
+    'flask exists in static-cache'
+  );
+  t.true(
+    pathExistsSync(
+      `${cachepath}${sep}${cacheFolderHash}_${arch}_slspyc${sep}.completed_requirements`
+    ),
+    '.completed_requirements exists in static-cache'
+  );
 
-    // py3.7 checking that static cache actually pulls from cache (by poisoning it)
-    writeFileSync(
-      `${cachepath}${sep}${cacheFolderHash}_${arch}_slspyc${sep}injected_file_is_bad_form`,
-      'injected new file into static cache folder'
-    );
-    sls(['package'], { env: {} });
-    const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
-    t.true(
-      zipfiles.includes('injected_file_is_bad_form'),
-      "static cache is really used when running 'sls package' again"
-    );
+  // py3.7 checking that static cache actually pulls from cache (by poisoning it)
+  writeFileSync(
+    `${cachepath}${sep}${cacheFolderHash}_${arch}_slspyc${sep}injected_file_is_bad_form`,
+    'injected new file into static cache folder'
+  );
+  sls(['package'], { env: {} });
+  const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip');
+  t.true(
+    zipfiles.includes('injected_file_is_bad_form'),
+    "static cache is really used when running 'sls package' again"
+  );
 
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+  t.end();
+});
 
-test(
-  'py3.7 uses static cache with cacheLocation option',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    const cachepath = '.requirements-cache';
-    sls(['package'], { env: { cacheLocation: cachepath } });
-    const cacheFolderHash = sha256Path('.serverless/requirements.txt');
-    const arch = 'x86_64';
-    t.true(
-      pathExistsSync(
-        `${cachepath}${sep}${cacheFolderHash}_${arch}_slspyc${sep}flask`
-      ),
-      'flask exists in static-cache'
-    );
-    t.true(
-      pathExistsSync(
-        `${cachepath}${sep}${cacheFolderHash}_${arch}_slspyc${sep}.completed_requirements`
-      ),
-      '.completed_requirements exists in static-cache'
-    );
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+test('py3.7 uses static cache with cacheLocation option', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  const cachepath = '.requirements-cache';
+  sls(['package'], { env: { cacheLocation: cachepath } });
+  const cacheFolderHash = sha256Path('.serverless/requirements.txt');
+  const arch = 'x86_64';
+  t.true(
+    pathExistsSync(
+      `${cachepath}${sep}${cacheFolderHash}_${arch}_slspyc${sep}flask`
+    ),
+    'flask exists in static-cache'
+  );
+  t.true(
+    pathExistsSync(
+      `${cachepath}${sep}${cacheFolderHash}_${arch}_slspyc${sep}.completed_requirements`
+    ),
+    '.completed_requirements exists in static-cache'
+  );
+  t.end();
+});
 
 test(
   'py3.7 uses static cache with dockerizePip & slim option',
@@ -2306,7 +1580,7 @@ test(
 
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
+  { skip: !canUseDocker() || brokenOn('win32') }
 );
 
 test(
@@ -2332,38 +1606,31 @@ test(
 
     t.end();
   },
-  { skip: !canUseDocker() || !hasPython(3.7) || brokenOn('win32') }
+  { skip: !canUseDocker() || brokenOn('win32') }
 );
 
-test(
-  'py3.7 can ignore functions defined with `image`',
-  async (t) => {
-    process.chdir('tests/base');
-    const path = npm(['pack', '../..']);
-    npm(['i', path]);
-    sls(['package'], { env: { individually: 'true' } });
-    t.true(
-      pathExistsSync('.serverless/hello.zip'),
-      'function hello is packaged'
-    );
-    t.true(
-      pathExistsSync('.serverless/hello2.zip'),
-      'function hello2 is packaged'
-    );
-    t.true(
-      pathExistsSync('.serverless/hello3.zip'),
-      'function hello3 is packaged'
-    );
-    t.true(
-      pathExistsSync('.serverless/hello4.zip'),
-      'function hello4 is packaged'
-    );
-    t.false(
-      pathExistsSync('.serverless/hello5.zip'),
-      'function hello5 is not packaged'
-    );
+test('py3.7 can ignore functions defined with `image`', async (t) => {
+  process.chdir('tests/base');
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  sls(['package'], { env: { individually: 'true' } });
+  t.true(pathExistsSync('.serverless/hello.zip'), 'function hello is packaged');
+  t.true(
+    pathExistsSync('.serverless/hello2.zip'),
+    'function hello2 is packaged'
+  );
+  t.true(
+    pathExistsSync('.serverless/hello3.zip'),
+    'function hello3 is packaged'
+  );
+  t.true(
+    pathExistsSync('.serverless/hello4.zip'),
+    'function hello4 is packaged'
+  );
+  t.false(
+    pathExistsSync('.serverless/hello5.zip'),
+    'function hello5 is not packaged'
+  );
 
-    t.end();
-  },
-  { skip: !hasPython(3.7) }
-);
+  t.end();
+});

--- a/test.js
+++ b/test.js
@@ -1634,3 +1634,23 @@ test('py3.7 can ignore functions defined with `image`', async (t) => {
 
   t.end();
 });
+
+test('poetry py3.7 fails packaging if poetry.lock is missing and flag requirePoetryLockFile is set to true', async (t) => {
+  copySync('tests/poetry', 'tests/base with a space');
+  process.chdir('tests/base with a space');
+  removeSync('poetry.lock');
+
+  const path = npm(['pack', '../..']);
+  npm(['i', path]);
+  const stdout = sls(['package'], {
+    env: { requirePoetryLockFile: 'true', slim: 'true' },
+    noThrow: true,
+  });
+  t.true(
+    stdout.includes(
+      'poetry.lock file not found - set requirePoetryLockFile to false to disable this error'
+    ),
+    'flag works and error is properly reported'
+  );
+  t.end();
+});

--- a/test.js
+++ b/test.js
@@ -212,6 +212,7 @@ test(
         dockerImage: 'break the build to log the command',
       },
     });
+    console.log('STDOUT', stdout);
     t.true(
       stdout.includes(
         `-v ${__dirname}${sep}tests${sep}base${sep}custom_ssh:/root/.ssh/custom_ssh:z`

--- a/tests/base/serverless.yml
+++ b/tests/base/serverless.yml
@@ -2,7 +2,7 @@ service: sls-py-req-test
 
 provider:
   name: aws
-  runtime: ${env:runtime, 'python3.6'}
+  runtime: ${env:runtime, 'python3.7'}
 
 plugins:
   - serverless-python-requirements

--- a/tests/individually/serverless.yml
+++ b/tests/individually/serverless.yml
@@ -2,7 +2,7 @@ service: sls-py-req-test-indiv
 
 provider:
   name: aws
-  runtime: python3.6
+  runtime: python3.7
 
 package:
   individually: true

--- a/tests/non_build_pyproject/serverless.yml
+++ b/tests/non_build_pyproject/serverless.yml
@@ -2,7 +2,7 @@ service: sls-py-req-test
 
 provider:
   name: aws
-  runtime: python3.6
+  runtime: python3.7
 
 plugins:
   - serverless-python-requirements

--- a/tests/non_poetry_pyproject/serverless.yml
+++ b/tests/non_poetry_pyproject/serverless.yml
@@ -2,7 +2,7 @@ service: sls-py-req-test
 
 provider:
   name: aws
-  runtime: python3.6
+  runtime: python3.7
 
 plugins:
   - serverless-python-requirements

--- a/tests/pipenv/serverless.yml
+++ b/tests/pipenv/serverless.yml
@@ -2,7 +2,7 @@ service: sls-py-req-test
 
 provider:
   name: aws
-  runtime: python3.6
+  runtime: python3.7
 
 plugins:
   - serverless-python-requirements

--- a/tests/poetry/serverless.yml
+++ b/tests/poetry/serverless.yml
@@ -13,6 +13,7 @@ custom:
     slimPatterns: ${file(./slimPatterns.yml):slimPatterns, self:custom.defaults.slimPatterns}
     slimPatternsAppendDefaults: ${env:slimPatternsAppendDefaults, self:custom.defaults.slimPatternsAppendDefaults}
     dockerizePip: ${env:dockerizePip, self:custom.defaults.dockerizePip}
+    requirePoetryLockFile: ${env:requirePoetryLockFile, false}
   defaults:
     zip: false
     slimPatterns: false

--- a/tests/poetry/serverless.yml
+++ b/tests/poetry/serverless.yml
@@ -2,7 +2,7 @@ service: sls-py-req-test
 
 provider:
   name: aws
-  runtime: python3.6
+  runtime: python3.7
 
 plugins:
   - serverless-python-requirements

--- a/tests/poetry_individually/serverless.yml
+++ b/tests/poetry_individually/serverless.yml
@@ -2,7 +2,7 @@ service: sls-py-req-test
 
 provider:
   name: aws
-  runtime: python3.6
+  runtime: python3.7
 
 plugins:
   - serverless-python-requirements


### PR DESCRIPTION
* Distinct logging whether the requirements.txt file is generated from poetry.lock vs pyproject.toml.
* New boolean flag: requirePoetryLockFile - When set to true, fail the build when poetry.lock is missing. This helps with creating reproducible builds where you want to have a fixed poetry.lock file instead of one generated on the fly.